### PR TITLE
Fix panic when using linear or ZOH resampling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "libsamplerate"
 authors = ["Ramy <RamiHg@users.noreply.github.com>"]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2018"
 
 description = "A pure C2Rust transpiled version of libsamplerate."

--- a/src/samplerate.rs
+++ b/src/samplerate.rs
@@ -17,43 +17,28 @@ extern "C" {
     /* __cplusplus */
     /* Opaque data type SRC_STATE. */
    
-    #[no_mangle]
     fn calloc(_: libc::c_ulong, _: libc::c_ulong) -> *mut libc::c_void;
-    #[no_mangle]
     fn free(_: *mut libc::c_void);
-    #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong)
      -> *mut libc::c_void;
-    #[no_mangle]
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong)
      -> *mut libc::c_void;
-    #[no_mangle]
     fn linear_set_converter(psrc: *mut SRC_PRIVATE, src_enum: libc::c_int)
      -> libc::c_int;
-    #[no_mangle]
     fn zoh_set_converter(psrc: *mut SRC_PRIVATE, src_enum: libc::c_int)
      -> libc::c_int;
-    #[no_mangle]
     fn sinc_set_converter(psrc: *mut SRC_PRIVATE, src_enum: libc::c_int)
      -> libc::c_int;
-    #[no_mangle]
     fn fabs(_: libc::c_double) -> libc::c_double;
     /* In src_linear.c */
-    #[no_mangle]
     fn linear_get_name(src_enum: libc::c_int) -> *const libc::c_char;
     /* In src_zoh.c */
-    #[no_mangle]
     fn zoh_get_name(src_enum: libc::c_int) -> *const libc::c_char;
     /* In src_sinc.c */
-    #[no_mangle]
     fn sinc_get_name(src_enum: libc::c_int) -> *const libc::c_char;
-    #[no_mangle]
     fn linear_get_description(src_enum: libc::c_int) -> *const libc::c_char;
-    #[no_mangle]
     fn zoh_get_description(src_enum: libc::c_int) -> *const libc::c_char;
-    #[no_mangle]
     fn sinc_get_description(src_enum: libc::c_int) -> *const libc::c_char;
-    #[no_mangle]
     fn lrint(_: libc::c_double) -> libc::c_long;
 }
 pub type SRC_STATE = SRC_STATE_tag;

--- a/src/src_linear.rs
+++ b/src/src_linear.rs
@@ -1,18 +1,11 @@
 use libc;
 extern "C" {
-    #[no_mangle]
     fn calloc(_: libc::c_ulong, _: libc::c_ulong) -> *mut libc::c_void;
-    #[no_mangle]
     fn free(_: *mut libc::c_void);
-    #[no_mangle]
     fn exit(_: libc::c_int) -> !;
-    #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong) -> *mut libc::c_void;
-    #[no_mangle]
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong) -> *mut libc::c_void;
-    #[no_mangle]
     fn fabs(_: libc::c_double) -> libc::c_double;
-    #[no_mangle]
     fn lrint(_: libc::c_double) -> libc::c_long;
 }
 pub type __darwin_size_t = libc::c_ulong;

--- a/src/src_linear.rs
+++ b/src/src_linear.rs
@@ -236,7 +236,7 @@ unsafe extern "C" fn linear_vari_process(
     if 0 != (*priv_0).reset {
         ch = 0i32;
         while ch < (*priv_0).channels {
-            (*priv_0).last_value[ch as usize] = *(*data).data_in.offset(ch as isize);
+            *(*priv_0).last_value.get_unchecked_mut(ch as usize) = *(*data).data_in.offset(ch as isize);
             ch += 1
         }
         (*priv_0).reset = 0i32
@@ -267,9 +267,9 @@ unsafe extern "C" fn linear_vari_process(
         ch = 0i32;
         while ch < (*priv_0).channels {
             *(*data).data_out.offset((*priv_0).out_gen as isize) =
-                ((*priv_0).last_value[ch as usize] as libc::c_double
+                (*(*priv_0).last_value.get_unchecked(ch as usize) as libc::c_double
                     + input_index
-                        * (*(*data).data_in.offset(ch as isize) - (*priv_0).last_value[ch as usize])
+                        * (*(*data).data_in.offset(ch as isize) - *(*priv_0).last_value.get_unchecked(ch as usize))
                             as libc::c_double) as libc::c_float;
             (*priv_0).out_gen += 1;
             ch += 1
@@ -328,7 +328,7 @@ unsafe extern "C" fn linear_vari_process(
     if (*priv_0).in_used > 0i32 as libc::c_long {
         ch = 0i32;
         while ch < (*priv_0).channels {
-            (*priv_0).last_value[ch as usize] = *(*data).data_in.offset(
+            *(*priv_0).last_value.get_unchecked_mut(ch as usize) = *(*data).data_in.offset(
                 ((*priv_0).in_used - (*priv_0).channels as libc::c_long + ch as libc::c_long)
                     as isize,
             );

--- a/src/src_zoh.rs
+++ b/src/src_zoh.rs
@@ -227,7 +227,7 @@ unsafe extern "C" fn zoh_vari_process(mut psrc: *mut SRC_PRIVATE,
     if 0 != (*priv_0).reset {
         ch = 0i32;
         while ch < (*priv_0).channels {
-            (*priv_0).last_value[ch as usize] =
+            *(*priv_0).last_value.get_unchecked_mut(ch as usize) =
                 *(*data).data_in.offset(ch as isize);
             ch += 1
         }
@@ -261,7 +261,7 @@ unsafe extern "C" fn zoh_vari_process(mut psrc: *mut SRC_PRIVATE,
         ch = 0i32;
         while ch < (*priv_0).channels {
             *(*data).data_out.offset((*priv_0).out_gen as isize) =
-                (*priv_0).last_value[ch as usize];
+                *(*priv_0).last_value.get_unchecked(ch as usize);
             (*priv_0).out_gen += 1;
             ch += 1
         }
@@ -309,7 +309,7 @@ unsafe extern "C" fn zoh_vari_process(mut psrc: *mut SRC_PRIVATE,
     if (*priv_0).in_used > 0i32 as libc::c_long {
         ch = 0i32;
         while ch < (*priv_0).channels {
-            (*priv_0).last_value[ch as usize] =
+            *(*priv_0).last_value.get_unchecked_mut(ch as usize) =
                 *(*data).data_in.offset(((*priv_0).in_used -
                                              (*priv_0).channels as
                                                  libc::c_long +

--- a/src/src_zoh.rs
+++ b/src/src_zoh.rs
@@ -1,18 +1,12 @@
 use libc;
 extern "C" {
-    #[no_mangle]
     fn calloc(_: libc::c_ulong, _: libc::c_ulong) -> *mut libc::c_void;
-    #[no_mangle]
     fn free(_: *mut libc::c_void);
-    #[no_mangle]
     fn memcpy(_: *mut libc::c_void, _: *const libc::c_void, _: libc::c_ulong)
      -> *mut libc::c_void;
-    #[no_mangle]
     fn memset(_: *mut libc::c_void, _: libc::c_int, _: libc::c_ulong)
      -> *mut libc::c_void;
-    #[no_mangle]
     fn fabs(_: libc::c_double) -> libc::c_double;
-    #[no_mangle]
     fn lrint(_: libc::c_double) -> libc::c_long;
 }
 pub type __darwin_size_t = libc::c_ulong;


### PR DESCRIPTION
Currently linear and ZOH resampling causes a panic when using more than one channel because it tries to index the `last_value` array out-of-bounds. However, this is intended in the C version since this struct is used as a variable length array. The fix is to just use unchecked array indexing in Rust.

Also, the compiler was marking the `#[no_mangle]` on some of the methods as a warning, and it even mentioned this will be a hard error in future versions of the Rust compiler, so I went ahead and removed those as well.